### PR TITLE
Create SSTF disk_scheduling.py

### DIFF
--- a/Python/SSTF disk_scheduling.py
+++ b/Python/SSTF disk_scheduling.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+def sstf_disk_scheduling(requests, start_position):
+    total_head_movement = 0
+    current_position = start_position
+    sorted_requests = sorted(requests)
+
+    while sorted_requests:
+        # Find the closest request in terms of seek time
+        closest_request = min(sorted_requests, key=lambda req: abs(req - current_position))
+        total_head_movement += abs(current_position - closest_request)
+        current_position = closest_request
+        sorted_requests.remove(current_position)
+
+    return total_head_movement
+
+# Example usage
+requests = [98, 183, 37, 122, 14, 124, 65, 67]
+start_position = 53
+
+total_movement = sstf_disk_scheduling(requests, start_position)
+print(f"Total head movement: {total_movement} cylinders")


### PR DESCRIPTION
Disk scheduling algorithms are used to optimize the access of data on a disk by determining the order in which read/write requests should be serviced. One of the commonly used disk scheduling algorithms is the Shortest Seek Time First (SSTF) algorithm.

#code

import numpy as np

def sstf_disk_scheduling(requests, start_position):
    total_head_movement = 0
    current_position = start_position
    sorted_requests = sorted(requests)

    while sorted_requests:
        # Find the closest request in terms of seek time
        closest_request = min(sorted_requests, key=lambda req: abs(req - current_position))
        total_head_movement += abs(current_position - closest_request)
        current_position = closest_request
        sorted_requests.remove(current_position)

    return total_head_movement

# Example usage
requests = [98, 183, 37, 122, 14, 124, 65, 67]
start_position = 53

total_movement = sstf_disk_scheduling(requests, start_position)
print(f"Total head movement: {total_movement} cylinders")


#explanation

In this code, we define the sstf_disk_scheduling function, which takes a list of disk access requests (requests) and the starting position of the disk head (start_position) as input. The function calculates the total head movement using the SSTF algorithm.

The algorithm repeatedly selects the request that minimizes the seek time (the absolute difference between the current head position and the request position) until all requests have been serviced. The total head movement is accumulated and returned.

You can adapt this code to simulate disk scheduling for your specific set of requests and starting position.